### PR TITLE
vender:publish 廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 $ composer require --dev ucan-lab/laravel-dacapo
 ```
 
-## Publish the schema file
+## Generate default schema.yml
 
 ```
-$ php artisan vendor:publish --provider="UcanLab\LaravelDacapo\Providers\ConsoleServiceProvider"
+$ php artisan dacapo:init
 ```
+
+`database/schemas/default.yml`
 
 ## Generate migration files from schema.yml
 

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -18,7 +18,6 @@ class ConsoleServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $this->bootPublishes();
         $this->registerCommands();
     }
 
@@ -28,20 +27,6 @@ class ConsoleServiceProvider extends ServiceProvider
     public function register()
     {
         // register bindings
-    }
-
-    /**
-     * Bootstrap publishes
-     *
-     * @return void
-     */
-    protected function bootPublishes()
-    {
-        $schemaPath = __DIR__ . '/../Storage';
-
-        $this->publishes([
-            $schemaPath . '/schema.yml' => database_path('schema.yml'),
-        ]);
     }
 
     /**


### PR DESCRIPTION
## 概要

`schema.yml` を生成するコマンドを用意(#9)したので、 `vender:publish` は廃止します。

```
$ php artisan dacapo:init
```
