### PR TITLE
Fix: Use foreign key name

### DIFF
--- a/src/Migrations/Schema/Relation.php
+++ b/src/Migrations/Schema/Relation.php
@@ -40,7 +40,9 @@ class Relation
      */
     public function getDownForeignKeyLine(): string
     {
-        $str = "->dropForeign(['$this->foreign'])";
+        $str = $this->name
+            ? "->dropForeign('$this->name')"
+            : "->dropForeign(['$this->foreign'])";
 
         return '$table' . $str . ';';
     }
@@ -50,12 +52,11 @@ class Relation
      */
     private function getForeignKey(): string
     {
-        return sprintf(
-            "->foreign('%s')->references('%s')->on('%s')",
-            $this->foreign,
-            $this->references,
-            $this->on
-        );
+        $str = $this->name
+            ? "->foreign('$this->foreign', '$this->name')"
+            : "->foreign('$this->foreign')";
+
+        return "{$str}->references('$this->references')->on('$this->on')";
     }
 
     /**

--- a/tests/Storage/relation/migrations/1970_01_01_000000_create_tags_table.php
+++ b/tests/Storage/relation/migrations/1970_01_01_000000_create_tags_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/tests/Storage/relation/migrations/1970_01_01_000000_create_task_tag_table.php
+++ b/tests/Storage/relation/migrations/1970_01_01_000000_create_task_tag_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTaskTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_tag', function (Blueprint $table) {
+            $table->unsignedBigInteger('task_id');
+            $table->unsignedBigInteger('tag_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_tag');
+    }
+}

--- a/tests/Storage/relation/migrations/1970_01_01_000002_constraint_task_tag_relation.php
+++ b/tests/Storage/relation/migrations/1970_01_01_000002_constraint_task_tag_relation.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ConstraintTaskTagRelation extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('task_tag', function (Blueprint $table) {
+            $table->foreign('task_id', 'task_tag_custom_task_id_foreign')->references('id')->on('tasks');
+            $table->foreign('tag_id')->references('id')->on('tags');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('task_tag', function (Blueprint $table) {
+            $table->dropForeign('task_tag_custom_task_id_foreign');
+            $table->dropForeign(['tag_id']);
+        });
+    }
+}

--- a/tests/Storage/relation/schemas/schema.yml
+++ b/tests/Storage/relation/schemas/schema.yml
@@ -3,6 +3,11 @@ users:
     id: bigIncrements
     name: string
 
+tags:
+  columns:
+    id: bigIncrements
+    title: string
+
 tasks:
   relations:
     - foreign: user_id
@@ -12,3 +17,16 @@ tasks:
     id: bigIncrements
     user_id: unsignedBigInteger
     content: string
+
+task_tag:
+  relations:
+    - name: task_tag_custom_task_id_foreign
+      foreign: task_id
+      references: id
+      on: tasks
+    - foreign: tag_id
+      references: id
+      on: tags
+  columns:
+    task_id: unsignedBigInteger
+    tag_id: unsignedBigInteger


### PR DESCRIPTION
Currently the `relations[*].name` field is not used, but it should be used to determine the foreign key name.