### PR TITLE
[3.0] カラムタイプの引数指定方法の改善

### DIFF
--- a/src/Migrations/Schema/Column.php
+++ b/src/Migrations/Schema/Column.php
@@ -4,6 +4,8 @@ namespace UcanLab\LaravelDacapo\Migrations\Schema;
 
 class Column
 {
+    const RESERVED_COLUMN_TYPE = '__reserved_column_type';
+
     private $name;
     private $type;
     private $args;
@@ -37,22 +39,22 @@ class Column
         $this->name = $name;
 
         if ($name === 'rememberToken') {
-            $this->name = '__reserved_column_type';
+            $this->name = self::RESERVED_COLUMN_TYPE;
             $this->type = 'rememberToken';
         } elseif ($name === 'softDeletes') {
-            $this->name = '__reserved_column_type';
+            $this->name = self::RESERVED_COLUMN_TYPE;
             $this->type = 'softDeletes';
             $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif ($name === 'softDeletesTz') {
-            $this->name = '__reserved_column_type';
+            $this->name = self::RESERVED_COLUMN_TYPE;
             $this->type = 'softDeletesTz';
             $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif ($name === 'timestamps') {
-            $this->name = '__reserved_column_type';
+            $this->name = self::RESERVED_COLUMN_TYPE;
             $this->type = 'timestamps';
             $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif ($name === 'timestampsTz') {
-            $this->name = '__reserved_column_type';
+            $this->name = self::RESERVED_COLUMN_TYPE;
             $this->type = 'timestampsTz';
             $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif (is_string($attributes)) {
@@ -98,7 +100,7 @@ class Column
      */
     protected function getColumnType(): string
     {
-        if ($this->name === '__reserved_column_type') {
+        if ($this->name === self::RESERVED_COLUMN_TYPE) {
             if (is_null($this->args)) {
                 return sprintf('->%s()', $this->type);
             }

--- a/src/Migrations/Schema/Column.php
+++ b/src/Migrations/Schema/Column.php
@@ -103,6 +103,10 @@ class Column
                 return sprintf('->%s()', $this->type);
             }
             return sprintf("->%s(%s)", $this->type, $this->convertArgs());
+        } elseif ($this->type === 'enum') {
+            return sprintf("->%s('%s', [%s])", $this->type, $this->name, $this->convertArgsToArray());
+        } elseif ($this->type === 'set') {
+            return sprintf("->%s('%s', [%s])", $this->type, $this->name, $this->convertArgsToArray());
         } elseif (is_null($this->args)) {
             return sprintf("->%s('%s')", $this->type, $this->name);
         } else {
@@ -211,6 +215,19 @@ class Column
         }
 
         return null;
+    }
+
+    /**
+     * @return string
+     */
+    private function convertArgsToArray(): string
+    {
+        $str = '';
+        foreach ($this->args as $arg) {
+            $str .= ', ' . var_export($arg, true);
+        }
+
+        return ltrim($str, ', ');
     }
 
     /**

--- a/src/Migrations/Schema/Column.php
+++ b/src/Migrations/Schema/Column.php
@@ -102,7 +102,8 @@ class Column
             if (is_null($this->args)) {
                 return sprintf('->%s()', $this->type);
             }
-            return sprintf("->%s(%s)", $this->type, $this->convertArgs());
+
+            return sprintf('->%s(%s)', $this->type, $this->convertArgs());
         } elseif ($this->type === 'enum') {
             return sprintf("->%s('%s', [%s])", $this->type, $this->name, $this->convertArgsToArray());
         } elseif ($this->type === 'set') {

--- a/src/Migrations/Schema/Column.php
+++ b/src/Migrations/Schema/Column.php
@@ -6,6 +6,7 @@ class Column
 {
     private $name;
     private $type;
+    private $args;
     // column modifiers
     private $after;
     private $autoIncrement;
@@ -36,24 +37,29 @@ class Column
         $this->name = $name;
 
         if ($name === 'rememberToken') {
-            $this->name = null;
+            $this->name = '__reserved_column_type';
             $this->type = 'rememberToken';
         } elseif ($name === 'softDeletes') {
-            $this->name = null;
+            $this->name = '__reserved_column_type';
             $this->type = 'softDeletes';
+            $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif ($name === 'softDeletesTz') {
-            $this->name = null;
+            $this->name = '__reserved_column_type';
             $this->type = 'softDeletesTz';
+            $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif ($name === 'timestamps') {
-            $this->name = is_int($attributes) ? $attributes : null;
+            $this->name = '__reserved_column_type';
             $this->type = 'timestamps';
+            $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif ($name === 'timestampsTz') {
-            $this->name = is_int($attributes) ? $attributes : null;
+            $this->name = '__reserved_column_type';
             $this->type = 'timestampsTz';
+            $this->args = isset($attributes['args']) ? $attributes['args'] : $attributes;
         } elseif (is_string($attributes)) {
             $this->type = $attributes;
         } elseif (is_array($attributes)) {
             $this->type = $attributes['type'];
+            $this->args = $attributes['args'] ?? null;
             $this->after = $attributes['after'] ?? null;
             $this->autoIncrement = $attributes['autoIncrement'] ?? null;
             $this->charset = $attributes['charset'] ?? null;
@@ -92,30 +98,16 @@ class Column
      */
     protected function getColumnType(): string
     {
-        if ($this->type === 'rememberToken') {
-            return '->rememberToken()';
-        } elseif ($this->type === 'softDeletes') {
-            return '->softDeletes()';
-        } elseif ($this->type === 'softDeletesTz') {
-            return '->softDeletesTz()';
-        } elseif ($this->type === 'timestamps') {
-            return '->timestamps(' . ($this->name ?: '') . ')';
-        } elseif ($this->type === 'timestampsTz') {
-            return '->timestampsTz(' . ($this->name ?: '') . ')';
+        if ($this->name === '__reserved_column_type') {
+            if (is_null($this->args)) {
+                return sprintf('->%s()', $this->type);
+            }
+            return sprintf("->%s(%s)", $this->type, $this->convertArgs());
+        } elseif (is_null($this->args)) {
+            return sprintf("->%s('%s')", $this->type, $this->name);
+        } else {
+            return sprintf("->%s('%s'%s)", $this->type, $this->name, $this->convertArgs(true));
         }
-
-        preg_match('/\((.*)\)/', $this->type, $match);
-        $digits = isset($match[1]) ? $match[1] : 0;
-
-        $columnName = "'$this->name'";
-
-        if ($digits) {
-            $columnName .= ', ' . $digits;
-        }
-
-        $type = substr($this->type, 0, strcspn($this->type, '('));
-
-        return '->' . $type . "($columnName)";
     }
 
     /**
@@ -219,5 +211,29 @@ class Column
         }
 
         return null;
+    }
+
+    /**
+     * @param bool $prefix
+     * @return string
+     */
+    private function convertArgs(bool $prefix = false): string
+    {
+        $str = '';
+        if (is_null($this->args)) {
+            return '';
+        } elseif (is_array($this->args)) {
+            foreach ($this->args as $arg) {
+                $str .= ', ' . var_export($arg, true);
+            }
+        } else {
+            $str = ', ' . var_export($this->args, true);
+        }
+
+        if (! $prefix) {
+            return ltrim($str, ', ');
+        }
+
+        return $str;
     }
 }

--- a/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args1_table.php
+++ b/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args1_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateColumnArgs1Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('column_args1', function (Blueprint $table) {
+            $table->bigInteger('id');
+            $table->string('name1', 128);
+            $table->string('name2');
+            $table->string('name3');
+            $table->decimal('price1', 8, 2);
+            $table->decimal('price2');
+            $table->decimal('price3');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('column_args1');
+    }
+}

--- a/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args2_table.php
+++ b/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args2_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateColumnArgs2Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('column_args2', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps(0);
+            $table->softDeletes('deleted_at', 0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('column_args2');
+    }
+}

--- a/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args3_table.php
+++ b/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args3_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateColumnArgs3Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('column_args3', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->softDeletes('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('column_args3');
+    }
+}

--- a/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args4_table.php
+++ b/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args4_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateColumnArgs4Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('column_args4', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps(0);
+            $table->softDeletes('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('column_args4');
+    }
+}

--- a/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args5_table.php
+++ b/tests/Storage/column_args/migrations/1970_01_01_000000_create_column_args5_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateColumnArgs5Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('column_args5', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('column_args5');
+    }
+}

--- a/tests/Storage/column_args/schemas/schema.yml
+++ b/tests/Storage/column_args/schemas/schema.yml
@@ -1,0 +1,38 @@
+column_args1:
+  columns:
+    id:
+      type: bigInteger
+    name1:
+      type: string
+      args: 128
+    name2:
+      type: string
+    name3: string
+    price1:
+      type: decimal
+      args: [8, 2]
+    price2:
+      type: decimal
+    price3: decimal
+column_args2:
+  columns:
+    id:
+      type: bigIncrements
+    timestamps:
+      args: [0]
+    softDeletes:
+      args: ['deleted_at', 0]
+column_args3:
+  columns:
+    id: bigIncrements
+    softDeletes: ['deleted_at']
+column_args4:
+  columns:
+    id: bigIncrements
+    timestamps: 0
+    softDeletes: 'deleted_at'
+column_args5:
+  columns:
+    id: bigIncrements
+    timestamps:
+    softDeletes:

--- a/tests/Storage/column_type/schemas/schema.yml
+++ b/tests/Storage/column_type/schemas/schema.yml
@@ -9,7 +9,8 @@ column_type1:
     confirmed:
       type: boolean
     name:
-      type: char(100)
+      type: char
+      args: 100
     created_date:
       type: date
     created_at:
@@ -17,13 +18,17 @@ column_type1:
     created_tz:
       type: dateTimeTz
     amount:
-      type: decimal(8, 2)
+      type: decimal
+      args: [8, 2]
     total:
-      type: double(8, 2)
+      type: double
+      args: [8, 2]
     level:
-      type: enum(['easy', 'hard'])
+      type: enum
+      args: ['easy', 'hard']
     subtotal:
-      type: float(8, 2)
+      type: float
+      args: [8, 2]
     positions:
       type: geometry
     positions_collection:
@@ -67,18 +72,21 @@ column_type3:
     positions_multi_polygon:
       type: multiPolygon
     taggable_nullable:
-      type: nullableMorphs('custom_taggable_nullable_index')
+      type: nullableMorphs
+      args: custom_taggable_nullable_index
     taggable_nullable_uuid:
-      type: nullableMorphs('custom_taggable_nullable_nullable_morphs_index')
+      type: nullableMorphs
+      args: custom_taggable_nullable_nullable_morphs_index
     position_point:
       type: point
     positions_polygon:
       type: polygon
     flavors:
-      type: set(['strawberry', 'vanilla'])
-    rememberToken: true
-    softDeletes: true
-    timestamps: true
+      type: set
+      args: ['strawberry', 'vanilla']
+    rememberToken:
+    softDeletes:
+    timestamps:
 
 column_type4:
   columns:
@@ -87,7 +95,8 @@ column_type4:
     votes:
       type: smallInteger
     name:
-      type: string(100)
+      type: string
+      args: 100
     description:
       type: text
     sunrise:
@@ -98,8 +107,8 @@ column_type4:
       type: timestamp
     added_on_tz:
       type: timestampTz
-    softDeletesTz: true
-    timestampsTz: true
+    softDeletesTz:
+    timestampsTz:
 
 column_type5:
   columns:
@@ -118,7 +127,8 @@ column_type5:
     votes_uti:
       type: unsignedTinyInteger
     amount:
-      type: unsignedDecimal(8, 2)
+      type: unsignedDecimal
+      args: [8, 2]
     uuid:
       type: uuid
     birth_year:

--- a/tests/Storage/laravel50_default/schemas/schema.yml
+++ b/tests/Storage/laravel50_default/schemas/schema.yml
@@ -11,8 +11,8 @@ users:
       nullable: true
     password:
       type: string
-    rememberToken: true
-    timestamps: true
+    rememberToken:
+    timestamps:
 
 password_resets:
   columns:

--- a/tests/Storage/laravel57_default/schemas/schema.yml
+++ b/tests/Storage/laravel57_default/schemas/schema.yml
@@ -11,8 +11,8 @@ users:
       nullable: true
     password:
       type: string
-    rememberToken: true
-    timestamps: true
+    rememberToken:
+    timestamps:
 
 password_resets:
   columns:

--- a/tests/Storage/laravel60_default/schemas/schema.yml
+++ b/tests/Storage/laravel60_default/schemas/schema.yml
@@ -9,8 +9,8 @@ users:
       type: timestamp
       nullable: true
     password: string
-    rememberToken: true
-    timestamps: true
+    rememberToken:
+    timestamps:
 
 password_resets:
   columns:


### PR DESCRIPTION
## 概要

#81

## 変更点

### 現在

```
price:
  type: decimal(8, 2)
timestamps: true
softDeletes: true
```

### 改修後

```
price:
  type: decimal
  args: [8, 2]
timestamps:
timestamps:
  args: [0]
timestamps: [0]
timestamps: 0
softDeletes:
softDeletes:
  args: ['deleted_at', 0]
softDeletes: 'deleted_at'
softDeletes: ['deleted_at']
softDeletes: ['deleted_at', 0]
```

## 補足

### enum, set

SETカラム, ENUMカラムは args は配列のみ受付けるため個別に処理している。

## 参考リンク

- https://readouble.com/laravel/6.x/ja/migrations.html
