### PR TITLE
Alias "args" with "length"

### DIFF
--- a/src/Migrations/Schema/Column.php
+++ b/src/Migrations/Schema/Column.php
@@ -61,7 +61,7 @@ class Column
             $this->type = $attributes;
         } elseif (is_array($attributes)) {
             $this->type = $attributes['type'];
-            $this->args = $attributes['args'] ?? null;
+            $this->args = $attributes['args'] ?? ($attributes['length'] ?? null);
             $this->after = $attributes['after'] ?? null;
             $this->autoIncrement = $attributes['autoIncrement'] ?? null;
             $this->charset = $attributes['charset'] ?? null;


### PR DESCRIPTION
In case of char or string, this is much readable than "args":

```
    name:
      type: string
      length: 32
```