### PR TITLE
[4.0]Migration file prefix date specification option

### DIFF
--- a/src/Console/DacapoCommand.php
+++ b/src/Console/DacapoCommand.php
@@ -2,6 +2,8 @@
 
 namespace UcanLab\LaravelDacapo\Console;
 
+use DateTime;
+use Exception;
 use Illuminate\Console\ConfirmableTrait;
 use UcanLab\LaravelDacapo\Dacapo\UseCase\Console\DacapoCommandUseCase;
 
@@ -22,6 +24,7 @@ class DacapoCommand extends Command
         {--no-migrate : Do not migrate}
         {--seed : Seed the database with records}
         {--refresh : Migrate refresh (for debug)}
+        {--prefix=1970-01-01 : Prefix date of the output migration file}
     ';
 
     /**
@@ -51,7 +54,15 @@ class DacapoCommand extends Command
     {
         $this->call('dacapo:clear', ['--force' => true]);
 
-        $fileList = $this->useCase->handle();
+        try {
+            $prefixDate = new DateTime($this->option('prefix'));
+        } catch (Exception $exception) {
+            $this->error('Error: Set the --prefix option to a value that can be converted to a date type.');
+
+            return;
+        }
+
+        $fileList = $this->useCase->handle($prefixDate);
 
         foreach ($fileList as $file) {
             $this->line(sprintf('<fg=green>Generated:</> %s', $file->getName()));

--- a/src/Dacapo/UseCase/Console/DacapoCommandUseCase.php
+++ b/src/Dacapo/UseCase/Console/DacapoCommandUseCase.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Dacapo\UseCase\Console;
 
+use DateTime;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFileList;
 use UcanLab\LaravelDacapo\Dacapo\UseCase\Generator\MigrationGenerator;
 use UcanLab\LaravelDacapo\Dacapo\UseCase\Port\SchemaListRepository;
@@ -23,10 +24,11 @@ class DacapoCommandUseCase
     }
 
     /**
+     * @param DateTime $prefixDate
      * @return MigrationFileList
      */
-    public function handle(): MigrationFileList
+    public function handle(DateTime $prefixDate): MigrationFileList
     {
-        return $this->generator->generate($this->repository->get());
+        return $this->generator->generate($prefixDate, $this->repository->get());
     }
 }

--- a/src/Dacapo/UseCase/Converter/SchemaToConstraintForeignKeyMigrationConverter.php
+++ b/src/Dacapo/UseCase/Converter/SchemaToConstraintForeignKeyMigrationConverter.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Dacapo\UseCase\Converter;
 
+use DateTime;
 use Illuminate\Support\Str;
 use UcanLab\LaravelDacapo\Dacapo\Domain\Entity\Schema;
 use UcanLab\LaravelDacapo\Dacapo\Domain\Entity\SchemaList;
@@ -11,7 +12,16 @@ use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFileList;
 class SchemaToConstraintForeignKeyMigrationConverter
 {
     const MIGRATION_COLUMN_INDENT = '            ';
-    protected Schema $schema;
+    protected DateTime $prefixDate;
+
+    /**
+     * SchemaToConstraintForeignKeyMigrationConverter constructor.
+     * @param DateTime $prefixDate
+     */
+    public function __construct(DateTime $prefixDate)
+    {
+        $this->prefixDate = $prefixDate;
+    }
 
     /**
      * @param SchemaList $schemaList
@@ -31,6 +41,17 @@ class SchemaToConstraintForeignKeyMigrationConverter
     }
 
     /**
+     * @param DateTime $prefixDate
+     * @return $this
+     */
+    public function setPrefixDate(DateTime $prefixDate): self
+    {
+        $this->prefixDate = $prefixDate;
+
+        return $this;
+    }
+
+    /**
      * @param Schema $schema
      * @return MigrationFile
      */
@@ -45,7 +66,7 @@ class SchemaToConstraintForeignKeyMigrationConverter
      */
     protected function makeMigrationFileName(Schema $schema): string
     {
-        return sprintf('1970_01_01_000003_%s.php', $this->makeMigrationName($schema));
+        return sprintf('%s_000003_%s.php', $this->prefixDate->format('Y_m_d'), $this->makeMigrationName($schema));
     }
 
     /**

--- a/src/Dacapo/UseCase/Converter/SchemaToCreateIndexMigrationConverter.php
+++ b/src/Dacapo/UseCase/Converter/SchemaToCreateIndexMigrationConverter.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Dacapo\UseCase\Converter;
 
+use DateTime;
 use Illuminate\Support\Str;
 use UcanLab\LaravelDacapo\Dacapo\Domain\Entity\Schema;
 use UcanLab\LaravelDacapo\Dacapo\Domain\Entity\SchemaList;
@@ -11,7 +12,27 @@ use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFileList;
 class SchemaToCreateIndexMigrationConverter
 {
     const MIGRATION_COLUMN_INDENT = '            ';
-    protected Schema $schema;
+    protected DateTime $prefixDate;
+
+    /**
+     * SchemaToCreateIndexMigrationConverter constructor.
+     * @param DateTime $prefixDate
+     */
+    public function __construct(DateTime $prefixDate)
+    {
+        $this->prefixDate = $prefixDate;
+    }
+
+    /**
+     * @param DateTime $prefixDate
+     * @return $this
+     */
+    public function setPrefixDate(DateTime $prefixDate): self
+    {
+        $this->prefixDate = $prefixDate;
+
+        return $this;
+    }
 
     /**
      * @param SchemaList $schemaList
@@ -45,7 +66,7 @@ class SchemaToCreateIndexMigrationConverter
      */
     protected function makeMigrationFileName(Schema $schema): string
     {
-        return sprintf('1970_01_01_000002_%s.php', $this->makeMigrationName($schema));
+        return sprintf('%s_000002_%s.php', $this->prefixDate->format('Y_m_d'), $this->makeMigrationName($schema));
     }
 
     /**

--- a/src/Dacapo/UseCase/Converter/SchemaToCreateTableMigrationConverter.php
+++ b/src/Dacapo/UseCase/Converter/SchemaToCreateTableMigrationConverter.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Dacapo\UseCase\Converter;
 
+use DateTime;
 use Illuminate\Support\Str;
 use UcanLab\LaravelDacapo\Dacapo\Domain\Entity\Schema;
 use UcanLab\LaravelDacapo\Dacapo\Domain\Entity\SchemaList;
@@ -14,10 +15,28 @@ class SchemaToCreateTableMigrationConverter
     const MIGRATION_COLUMN_INDENT = '            ';
 
     protected DatabaseBuilder $databaseBuilder;
+    protected DateTime $prefixDate;
 
-    public function __construct(DatabaseBuilder $databaseBuilder)
+    /**
+     * SchemaToCreateTableMigrationConverter constructor.
+     * @param DatabaseBuilder $databaseBuilder
+     * @param DateTime $prefixDate
+     */
+    public function __construct(DatabaseBuilder $databaseBuilder, DateTime $prefixDate)
     {
         $this->databaseBuilder = $databaseBuilder;
+        $this->prefixDate = $prefixDate;
+    }
+
+    /**
+     * @param DateTime $prefixDate
+     * @return $this
+     */
+    public function setPrefixDate(DateTime $prefixDate): self
+    {
+        $this->prefixDate = $prefixDate;
+
+        return $this;
     }
 
     /**
@@ -52,7 +71,7 @@ class SchemaToCreateTableMigrationConverter
      */
     protected function makeMigrationFileName(Schema $schema): string
     {
-        return sprintf('1970_01_01_000001_%s.php', $this->makeMigrationName($schema));
+        return sprintf('%s_000001_%s.php', $this->prefixDate->format('Y_m_d'), $this->makeMigrationName($schema));
     }
 
     /**

--- a/src/Dacapo/UseCase/Generator/MigrationGenerator.php
+++ b/src/Dacapo/UseCase/Generator/MigrationGenerator.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Dacapo\UseCase\Generator;
 
+use DateTime;
 use UcanLab\LaravelDacapo\Dacapo\Domain\Entity\SchemaList;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFileList;
 use UcanLab\LaravelDacapo\Dacapo\UseCase\Converter\SchemaToConstraintForeignKeyMigrationConverter;
@@ -36,11 +37,16 @@ class MigrationGenerator
     }
 
     /**
+     * @param DateTime $prefixDate
      * @param SchemaList $schemaList
      * @return MigrationFileList
      */
-    public function generate(SchemaList $schemaList): MigrationFileList
+    public function generate(DateTime $prefixDate, SchemaList $schemaList): MigrationFileList
     {
+        $this->schemaToCreateTableMigrationConverter->setPrefixDate($prefixDate);
+        $this->schemaToCreateIndexMigrationConverter->setPrefixDate($prefixDate);
+        $this->schemaToConstraintForeignKeyMigrationConverter->setPrefixDate($prefixDate);
+
         $tableFileList = $this->generateCreateTable($schemaList);
         $indexFileList = $this->generateCreateIndex($schemaList);
         $foreignKeyFileList = $this->generateConstraintForeignKey($schemaList);

--- a/tests/Console/DacapoClearCommandTest.php
+++ b/tests/Console/DacapoClearCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Test\App\UseCase\Console;
 
+use DateTime;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFile;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFileList;
 use UcanLab\LaravelDacapo\Dacapo\Infra\Adapter\InMemoryMigrationListRepository;
@@ -14,6 +15,7 @@ class DacapoClearCommandTest extends TestCase
     public function testResolve(): void
     {
         $this->app->register(ConsoleServiceProvider::class);
+        $this->instance(DateTime::class, new DateTime());
         $this->instance(MigrationListRepository::class, new InMemoryMigrationListRepository(new MigrationFileList([
             new MigrationFile('1970_01_01_000000_create_users_table.php', ''),
             new MigrationFile('1970_01_01_000000_create_password_resets_table.php', ''),

--- a/tests/Console/DacapoCommandTest.php
+++ b/tests/Console/DacapoCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Test\App\UseCase\Console;
 
+use DateTime;
 use Illuminate\Support\Facades\File;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFile;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Migration\MigrationFileList;
@@ -29,6 +30,7 @@ class DacapoCommandTest extends TestCase
         $this->app->register(ConsoleServiceProvider::class);
 
         $actualMigrationFileList = new MigrationFileList();
+        $this->instance(DateTime::class, new DateTime());
         $this->instance(DatabaseBuilder::class, new MysqlDatabaseBuilder());
         $this->instance(SchemaListRepository::class, new InMemorySchemaListRepository($schemaFileList));
         $this->instance(MigrationListRepository::class, new InMemoryMigrationListRepository($actualMigrationFileList));
@@ -81,6 +83,7 @@ class DacapoCommandTest extends TestCase
         $this->app->register(ConsoleServiceProvider::class);
 
         $actualMigrationFileList = new MigrationFileList();
+        $this->instance(DateTime::class, new DateTime());
         $this->instance(DatabaseBuilder::class, new PostgresqlDatabaseBuilder());
         $this->instance(SchemaListRepository::class, new InMemorySchemaListRepository($schemaFileList));
         $this->instance(MigrationListRepository::class, new InMemoryMigrationListRepository($actualMigrationFileList));

--- a/tests/Console/DacapoInitCommandTest.php
+++ b/tests/Console/DacapoInitCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Test\App\UseCase\Console;
 
+use DateTime;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Schema\SchemaFileList;
 use UcanLab\LaravelDacapo\Dacapo\Infra\Adapter\InMemorySchemaListRepository;
 use UcanLab\LaravelDacapo\Dacapo\UseCase\Port\SchemaListRepository;
@@ -13,6 +14,7 @@ class DacapoInitCommandTest extends TestCase
     public function testResolve(): void
     {
         $this->app->register(ConsoleServiceProvider::class);
+        $this->instance(DateTime::class, new DateTime());
         $this->instance(SchemaListRepository::class, new InMemorySchemaListRepository(new SchemaFileList()));
         $this->artisan('dacapo:init')->assertExitCode(0);
     }

--- a/tests/Console/DacapoUninstallCommandTest.php
+++ b/tests/Console/DacapoUninstallCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace UcanLab\LaravelDacapo\Test\App\UseCase\Console;
 
+use DateTime;
 use UcanLab\LaravelDacapo\Dacapo\Domain\ValueObject\Schema\SchemaFileList;
 use UcanLab\LaravelDacapo\Dacapo\Infra\Adapter\InMemorySchemaListRepository;
 use UcanLab\LaravelDacapo\Dacapo\UseCase\Port\SchemaListRepository;
@@ -13,6 +14,7 @@ class DacapoUninstallCommandTest extends TestCase
     public function testResolve(): void
     {
         $this->app->register(ConsoleServiceProvider::class);
+        $this->instance(DateTime::class, new DateTime());
         $this->instance(SchemaListRepository::class, new InMemorySchemaListRepository(new SchemaFileList()));
         $this->artisan('dacapo:uninstall')->assertExitCode(0);
     }


### PR DESCRIPTION
close #123

## normal dacapo command

```
$ php artisan dacapo --no-migrate
Starting: laravel artisan dacapo command
Starting: laravel artisan dacapo:clear command
No migration file generated by Dacapo.
Finished: laravel artisan dacapo:clear command, 0.009948 seconds, max memory: 18 MB.
Generated: 1970_01_01_000001_create_failed_jobs_table.php
Generated: 1970_01_01_000001_create_password_resets_table.php
Generated: 1970_01_01_000001_create_users_table.php
No migrate.
Finished: laravel artisan dacapo command, 0.066127 seconds, max memory: 18 MB.
```

## dacapo command with --prefix option

```
$ php artisan dacapo --no-migrate --prefix=20200123
Starting: laravel artisan dacapo command
Starting: laravel artisan dacapo:clear command
No migration file generated by Dacapo.
Finished: laravel artisan dacapo:clear command, 0.011749 seconds, max memory: 18 MB.
Generated: 2020_01_23_000001_create_failed_jobs_table.php
Generated: 2020_01_23_000001_create_password_resets_table.php
Generated: 2020_01_23_000001_create_users_table.php
No migrate.
Finished: laravel artisan dacapo command, 0.071552 seconds, max memory: 18 MB.
```


