### PR TITLE
fix Drop personal_access_tokens

### DIFF
--- a/src/Dacapo/Presentation/Console/DacapoInitCommand/laravel8.yml
+++ b/src/Dacapo/Presentation/Console/DacapoInitCommand/laravel8.yml
@@ -35,20 +35,3 @@ failed_jobs:
     failed_at:
       type: timestamp
       useCurrent:
-
-personal_access_tokens:
-  columns:
-    id:
-    tokenable: morphs
-    name: string
-    token:
-      type: string
-      args: 64
-      unique:
-    abilities:
-      type: text
-      nullable:
-    last_used_at:
-      type: timestamp
-      nullable
-    timestamps:


### PR DESCRIPTION
If you need to migrate personal_access_tokens, execute the following command.

```
$ php artisan vendor:publish --tag=sanctum-migrations
```