### PR TITLE
fix dacapo:init Base table or view already exists: 1050 Table 'users' already exists

### DIFF
--- a/src/Dacapo/Presentation/Console/DacapoInitCommand.php
+++ b/src/Dacapo/Presentation/Console/DacapoInitCommand.php
@@ -45,7 +45,7 @@ final class DacapoInitCommand extends Command
         file_put_contents($to, file_get_contents($from));
         $this->line('<fg=green>Generated:</> database/schemas/default.yml');
 
-        $this->call('dacapo:clear', ['--all']);
+        $this->call('dacapo:clear', ['--all' => true]);
         $this->call('dacapo', ['--no-migrate' => $this->option('no-migrate')]);
     }
 }


### PR DESCRIPTION
close #191

https://laravel.com/docs/9.x/artisan#passing-boolean-values